### PR TITLE
Added tpl to enable templated config values

### DIFF
--- a/charts/renovate/templates/configmap.yaml
+++ b/charts/renovate/templates/configmap.yaml
@@ -7,5 +7,5 @@ metadata:
     {{- include "renovate.labels" . | nindent 4 }}
 data:
   config.json: |-
-    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" .Values.renovate.config | nindent 4 }}
+    {{- required "A valid .Values.renovate.config entry is required if existingConfigFile is not specified!" tpl .Values.renovate.config | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
We use [helm secrets](https://github.com/jkroepke/helm-secrets) to encrypt configuration values like credentials. To reference these it would be nice to be able to reference these in the configuration without creating a custom configmap. To allow for this the `tpl` function has been added in this PR.