### PR TITLE
Added ci-checks for k8s 1.28

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,11 @@ jobs:
       matrix:
         k8s:
           # from https://github.com/yannh/kubernetes-json-schema
-          - v1.24.13
-          - v1.25.9
-          - v1.26.4
-          - v1.27.1
+          - v1.24.17
+          - v1.25.14
+          - v1.26.9
+          - v1.27.6
+          - v1.28.2
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -88,6 +89,7 @@ jobs:
           - v1.25.11 # renovate: kindest
           - v1.26.6 # renovate: kindest
           - v1.27.3 # renovate: kindest
+          - v1.28.0 # renovate: kindest
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
k8s 1.28 is going to be/has been released to the major cloud providers this month